### PR TITLE
HOTFIX: Segfaulting library loading

### DIFF
--- a/include/functional_dag/lib_utils.h
+++ b/include/functional_dag/lib_utils.h
@@ -68,17 +68,16 @@ namespace fn_dag {
   typedef struct {
     OPTION_TYPE type;
     union {
-      const char * string_value;
-      int int_value;
+      const char* string_value;
+      int32_t int_value;
       bool bool_value;
     } value;
     uint32_t serial_id;
-    string option_prompt; 
-    string short_description;
+    const char* option_prompt; 
+    const char* short_description;
   } construction_option; 
 
   typedef vector<construction_option> lib_options;
-  // using module_getter_fn = module* (*)(const lib_options *);
 
   typedef struct {
     uint32_t lib_guid;
@@ -89,7 +88,6 @@ namespace fn_dag {
   } library_spec;
 
   using instantiate_fn = std::function<shared_ptr<module>(const lib_options * const)>;
-  // using instantiate_fn = module* (*)(const lib_options * const);
 }
 
 std::string fsys_serialize(const vector<fn_dag::library_spec> * const);

--- a/src/functional_dag/libutils.cpp
+++ b/src/functional_dag/libutils.cpp
@@ -185,7 +185,7 @@ static fn_dag::lib_options __generate_options(Json::Value spec_in) {
 }
 
 static std::shared_ptr<fn_dag::module> __instantiate_from_library(Json::Value node, const std::unordered_map<uint32_t, fn_dag::instantiate_fn> &library) {
-  long s_guid = __get_guid(node);
+  uint32_t s_guid = __get_guid(node);
   if(s_guid != 0) {
     fn_dag::instantiate_fn spec_creator = nullptr;
     if(library.contains(s_guid))


### PR DESCRIPTION
Unfortunately when memory is allocated in a dynamic link library and freed in the main executable space, a segfault is thrown. Since in most use cases these strings are on the string table of the dynamic library, we don't actually need to free them. What I'm doing now is to jus tset the pointer to the string table and not free the memory.